### PR TITLE
feat: [010-store-api-cart-crud] 장바구니 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 db
-redis
+redis-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
     ports:
       - 6379:6379
     volumes:
-      - ./redis/data:/data
-      - ./redis/conf/redis.conf:/usr/local/conf/redis.conf
+      - ./redis-db/data:/data
+      - ./redis-db/conf/redis.conf:/usr/local/conf/redis.conf
       # 컨테이너에 docker label을 이용해서 메타데이터 추가
     labels:
       - "name=redis"

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/redis/Cart.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/redis/Cart.java
@@ -1,0 +1,85 @@
+package com.zerobase.storeapi.domain.redis;
+
+import com.zerobase.storeapi.domain.redis.form.AddItemCartForm;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+
+import javax.persistence.Id;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+@RedisHash("cart")
+@Builder
+@AllArgsConstructor
+public class Cart {
+    @Id
+    private Long customerId;
+    private List<Item> items;
+    private List<String> messages;
+    private int totalPrice;
+
+    public void addMessage(String message) {
+        messages.add(message);
+    }
+
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Item implements Comparable<Item> {
+        private Long id;
+        private Long storeId;
+        private String storeName;
+        private String name;
+        private List<Option> options;
+
+
+        public static Item from(AddItemCartForm form) {
+            return Item.builder()
+                    .id(form.getId())
+                    .storeId(form.getStoreId())
+                    .storeName(form.getStoreName())
+                    .name(form.getName())
+                    .options(form.getOptions().stream().map(Option::from).collect(Collectors.toList()))
+                    .build();
+        }
+
+
+        @Override
+        public int compareTo(Item p) {
+            return (int) (getId() - p.getId());
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Option implements Comparable<Option> {
+        private Long id;
+        private String name;
+        private Integer quantity;
+        private Integer price;
+
+        public static Option from(AddItemCartForm.Option form) {
+            return Option.builder()
+                    .id(form.getId())
+                    .name(form.getName())
+                    .quantity(form.getQuantity())
+                    .price(form.getPrice())
+                    .build();
+        }
+
+        @Override
+        public int compareTo(Option pi) {
+            return (int) (getId() - pi.getId());
+        }
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/AddItemCartForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/AddItemCartForm.java
@@ -1,0 +1,31 @@
+package com.zerobase.storeapi.domain.redis.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AddItemCartForm {
+    private Long id;
+    private Long storeId;
+    private String storeName;
+    private String name;
+    private List<Option> options;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Option{
+        private Long id;
+        private String name;
+        private Integer quantity;
+        private Integer price;
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/DeleteOptionCartForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/DeleteOptionCartForm.java
@@ -1,0 +1,16 @@
+package com.zerobase.storeapi.domain.redis.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DeleteOptionCartForm {
+    private List<Long> optionIds;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/UpdateOptionCartForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/UpdateOptionCartForm.java
@@ -1,0 +1,16 @@
+package com.zerobase.storeapi.domain.redis.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UpdateOptionCartForm {
+    private Long itemId;
+    private Long optionId;
+    private Integer quantity;
+}


### PR DESCRIPTION
# feat: [010-store-api-cart-crud] 장바구니 기능 구현

- Redis이용해 장바구니 구현
- 장바구니 아이템 추가 구현
- 장바구니 아이템 수량 변경 구현
- 장바구니 아이템 삭제 구현
- 선택 주문시 주문하지 않은 아이템은 장바구니에 남도록 구현